### PR TITLE
forward controller 추가

### DIFF
--- a/src/main/java/com/tripmate/controller/ForwardController.java
+++ b/src/main/java/com/tripmate/controller/ForwardController.java
@@ -1,0 +1,24 @@
+package com.tripmate.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@Controller
+@RequestMapping("/forward")
+public class ForwardController {
+    @GetMapping(value = "/**/*.trip")
+    public String forwardJspPage(final HttpServletRequest request) {
+        String view = request.getRequestURI();
+
+        if (log.isDebugEnabled()) {
+            log.debug("forward jsp page url = " + view);
+        }
+
+        return view.substring(9, view.length() - 5);
+    }
+}


### PR DESCRIPTION
단순 jsp 페이지 호출 시 반복적인 메서드 작성을 줄이기 위한 forward controller를 추가하였습니다.
사용 시 /forward/JSP파일경로.trip 로 호출하시면 됩니다.
ex) http://localhost:8080/forward/member/signUpResult.trip